### PR TITLE
Allow untitled fields while parsing entries

### DIFF
--- a/kotpass/src/main/kotlin/app/keemobile/kotpass/constants/Defaults.kt
+++ b/kotpass/src/main/kotlin/app/keemobile/kotpass/constants/Defaults.kt
@@ -8,4 +8,5 @@ internal object Defaults {
     const val HistoryMaxItems = 10
     const val HistoryMaxSize = 6 * 1024 * 1024
     const val RecycleBinName = "Recycle Bin"
+    const val UntitledLabel = "Untitled"
 }

--- a/kotpass/src/main/kotlin/app/keemobile/kotpass/database/Decoder.kt
+++ b/kotpass/src/main/kotlin/app/keemobile/kotpass/database/Decoder.kt
@@ -1,5 +1,6 @@
 package app.keemobile.kotpass.database
 
+import app.keemobile.kotpass.constants.Defaults
 import app.keemobile.kotpass.cryptography.ContentEncryption
 import app.keemobile.kotpass.cryptography.EncryptionSaltGenerator
 import app.keemobile.kotpass.cryptography.KeyTransform
@@ -26,7 +27,8 @@ fun KeePassDatabase.Companion.decode(
     inputStream: InputStream,
     credentials: Credentials,
     validateHashes: Boolean = true,
-    contentParser: XmlContentParser = DefaultXmlContentParser
+    contentParser: XmlContentParser = DefaultXmlContentParser,
+    untitledLabel: String = Defaults.UntitledLabel
 ): KeePassDatabase {
     val headerBuffer = Buffer()
 
@@ -55,7 +57,8 @@ fun KeePassDatabase.Companion.decode(
                     XmlContext.Decode(
                         version = header.version,
                         encryption = saltGenerator,
-                        binaries = meta.binaries
+                        binaries = meta.binaries,
+                        untitledLabel = untitledLabel
                     )
                 }
                 val headerHash = content.meta.headerHash
@@ -99,7 +102,8 @@ fun KeePassDatabase.Companion.decode(
                     XmlContext.Decode(
                         version = header.version,
                         encryption = saltGenerator,
-                        binaries = innerHeader.binaries
+                        binaries = innerHeader.binaries,
+                        untitledLabel = untitledLabel
                     )
                 }
                 KeePassDatabase.Ver4x(credentials, header, content, innerHeader)
@@ -111,7 +115,8 @@ fun KeePassDatabase.Companion.decode(
 fun KeePassDatabase.Companion.decodeFromXml(
     inputStream: InputStream,
     credentials: Credentials,
-    contentParser: XmlContentParser = DefaultXmlContentParser
+    contentParser: XmlContentParser = DefaultXmlContentParser,
+    untitledLabel: String = Defaults.UntitledLabel
 ): KeePassDatabase {
     val header = DatabaseHeader.Ver4x.create()
     var innerHeader = DatabaseInnerHeader.create()
@@ -123,7 +128,8 @@ fun KeePassDatabase.Companion.decodeFromXml(
         XmlContext.Decode(
             version = header.version,
             encryption = saltGenerator,
-            binaries = meta.binaries
+            binaries = meta.binaries,
+            untitledLabel = untitledLabel
         )
     }
     innerHeader = innerHeader.copy(

--- a/kotpass/src/main/kotlin/app/keemobile/kotpass/models/XmlContext.kt
+++ b/kotpass/src/main/kotlin/app/keemobile/kotpass/models/XmlContext.kt
@@ -1,5 +1,6 @@
 package app.keemobile.kotpass.models
 
+import app.keemobile.kotpass.constants.Defaults
 import app.keemobile.kotpass.cryptography.EncryptionSaltGenerator
 import okio.ByteString
 
@@ -16,6 +17,7 @@ sealed class XmlContext {
     class Decode(
         override val version: FormatVersion,
         val encryption: EncryptionSaltGenerator,
-        val binaries: Map<ByteString, BinaryData>
+        val binaries: Map<ByteString, BinaryData>,
+        val untitledLabel: String = Defaults.UntitledLabel
     ) : XmlContext()
 }

--- a/kotpass/src/test/kotlin/app/keemobile/kotpass/common/DecodeFromResources.kt
+++ b/kotpass/src/test/kotlin/app/keemobile/kotpass/common/DecodeFromResources.kt
@@ -5,7 +5,9 @@ import app.keemobile.kotpass.database.KeePassDatabase
 import app.keemobile.kotpass.database.decode
 import app.keemobile.kotpass.xml.DefaultXmlContentParser
 import app.keemobile.kotpass.xml.XmlContentParser
+import org.jetbrains.annotations.TestOnly
 
+@TestOnly
 internal fun decodeFromResources(
     path: String,
     credentials: Credentials,

--- a/kotpass/src/test/kotlin/app/keemobile/kotpass/common/DecodeFromResources.kt
+++ b/kotpass/src/test/kotlin/app/keemobile/kotpass/common/DecodeFromResources.kt
@@ -1,4 +1,4 @@
-package app.keemobile.kotpass.resources
+package app.keemobile.kotpass.common
 
 import app.keemobile.kotpass.database.Credentials
 import app.keemobile.kotpass.database.KeePassDatabase

--- a/kotpass/src/test/kotlin/app/keemobile/kotpass/models/EntrySpec.kt
+++ b/kotpass/src/test/kotlin/app/keemobile/kotpass/models/EntrySpec.kt
@@ -1,6 +1,7 @@
 package app.keemobile.kotpass.models
 
 import app.keemobile.kotpass.builders.buildEntry
+import app.keemobile.kotpass.common.decodeFromResources
 import app.keemobile.kotpass.constants.BasicField
 import app.keemobile.kotpass.cryptography.EncryptedValue
 import app.keemobile.kotpass.cryptography.EncryptionSaltGenerator
@@ -10,7 +11,6 @@ import app.keemobile.kotpass.database.traverse
 import app.keemobile.kotpass.extensions.parseAsXml
 import app.keemobile.kotpass.resources.EntryRes
 import app.keemobile.kotpass.resources.TimeDataRes
-import app.keemobile.kotpass.resources.decodeFromResources
 import app.keemobile.kotpass.xml.unmarshalEntry
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldBeEmpty

--- a/kotpass/src/test/kotlin/app/keemobile/kotpass/models/EntrySpec.kt
+++ b/kotpass/src/test/kotlin/app/keemobile/kotpass/models/EntrySpec.kt
@@ -3,12 +3,14 @@ package app.keemobile.kotpass.models
 import app.keemobile.kotpass.builders.buildEntry
 import app.keemobile.kotpass.common.decodeFromResources
 import app.keemobile.kotpass.constants.BasicField
+import app.keemobile.kotpass.constants.Defaults
 import app.keemobile.kotpass.cryptography.EncryptedValue
 import app.keemobile.kotpass.cryptography.EncryptionSaltGenerator
 import app.keemobile.kotpass.database.Credentials
 import app.keemobile.kotpass.database.modifiers.binaries
 import app.keemobile.kotpass.database.traverse
 import app.keemobile.kotpass.extensions.parseAsXml
+import app.keemobile.kotpass.models.EntryValue.Plain
 import app.keemobile.kotpass.resources.EntryRes
 import app.keemobile.kotpass.resources.TimeDataRes
 import app.keemobile.kotpass.xml.unmarshalEntry
@@ -33,10 +35,18 @@ class EntrySpec : DescribeSpec({
 
             entry.tags.size shouldBe 3
             entry.tags.first() shouldBe "lorem"
+
             entry.fields["custom1"] shouldNotBe null
             entry.fields["custom2"] shouldNotBe null
+
+            entry.fields[Defaults.UntitledLabel] shouldBe Plain("content 1")
+            entry.fields["${Defaults.UntitledLabel} (1)"] shouldNotBe Plain("content 2")
+            entry.fields["${Defaults.UntitledLabel} (2)"] shouldBe Plain("content 2")
+            entry.fields["${Defaults.UntitledLabel} (3)"] shouldBe Plain("content 3")
+
             entry.times shouldNotBe null
             entry.times?.creationTime shouldBe TimeDataRes.ParsedDateTime
+
             entry.history.size shouldBe 1
             entry.binaries.size shouldBe 0
         }
@@ -52,7 +62,7 @@ class EntrySpec : DescribeSpec({
 
         it("Different order in fields should be reflected in equality check") {
             val uuid = UUID.randomUUID()
-            val someValue = EntryValue.Plain("Some")
+            val someValue = Plain("Some")
             val numberOfItems = 3
             val items = (0..numberOfItems).associate { "$it" to someValue }
             val reversed = (numberOfItems downTo 0).associate { "$it" to someValue }

--- a/kotpass/src/test/kotlin/app/keemobile/kotpass/resources/EntryRes.kt
+++ b/kotpass/src/test/kotlin/app/keemobile/kotpass/resources/EntryRes.kt
@@ -1,5 +1,7 @@
 package app.keemobile.kotpass.resources
 
+import app.keemobile.kotpass.constants.Defaults
+
 internal object EntryRes {
     val BasicXml = """
     <Entry>
@@ -25,6 +27,9 @@ internal object EntryRes {
             <Value>dummy</Value>
         </String>
         <String>
+            <Value>content 1</Value>
+        </String>
+        <String>
             <Key>Notes</Key>
             <Value></Value>
         </String>
@@ -43,6 +48,16 @@ internal object EntryRes {
         <String>
             <Key>UserName</Key>
             <Value>User</Value>
+        </String>
+        <String>
+            <Value>content 2</Value>
+        </String>
+        <String>
+            <Value>content 3</Value>
+        </String>
+        <String>
+            <Key>${Defaults.UntitledLabel} (1)</Key>
+            <Value>Fizz</Value>
         </String>
         <AutoType>
             <Enabled>True</Enabled>


### PR DESCRIPTION
# Description

Some databases may have malformed entry fields without IDs. 
It would be beneficial to recover these fields instead of failing.

## Related issues

#10 