### PR TITLE
Optimise decoder

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,5 +15,5 @@ spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 testing-kotest = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 
-kotlin-xml-builder = "org.redundent:kotlin-xml-builder:1.9.0"
+kotlin-xml-builder = "org.redundent:kotlin-xml-builder:1.9.1"
 okio = "com.squareup.okio:okio:3.9.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,4 +16,4 @@ kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref =
 testing-kotest = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 
 kotlin-xml-builder = "org.redundent:kotlin-xml-builder:1.9.0"
-okio = "com.squareup.okio:okio:3.2.0"
+okio = "com.squareup.okio:okio:3.9.0"

--- a/kotpass/src/main/kotlin/app/keemobile/kotpass/database/ContentBlocks.kt
+++ b/kotpass/src/main/kotlin/app/keemobile/kotpass/database/ContentBlocks.kt
@@ -6,6 +6,7 @@ import app.keemobile.kotpass.errors.FormatError
 import app.keemobile.kotpass.extensions.constantTimeEquals
 import app.keemobile.kotpass.extensions.sha256
 import app.keemobile.kotpass.extensions.sha512
+import app.keemobile.kotpass.io.BufferedStream
 import okio.Buffer
 import okio.BufferedSink
 import okio.BufferedSource
@@ -44,7 +45,7 @@ internal object ContentBlocks {
     }
 
     fun readContentBlocksVer4x(
-        source: BufferedSource,
+        source: BufferedStream,
         masterSeed: ByteArray,
         transformedKey: ByteArray
     ): ByteArray {

--- a/kotpass/src/main/kotlin/app/keemobile/kotpass/database/Decoder.kt
+++ b/kotpass/src/main/kotlin/app/keemobile/kotpass/database/Decoder.kt
@@ -10,12 +10,12 @@ import app.keemobile.kotpass.database.header.DatabaseInnerHeader
 import app.keemobile.kotpass.database.header.Signature
 import app.keemobile.kotpass.errors.CryptoError
 import app.keemobile.kotpass.errors.FormatError
-import app.keemobile.kotpass.extensions.teeBuffer
+import app.keemobile.kotpass.extensions.teeBufferStream
+import app.keemobile.kotpass.io.BufferedStream
 import app.keemobile.kotpass.models.XmlContext
 import app.keemobile.kotpass.xml.DefaultXmlContentParser
 import app.keemobile.kotpass.xml.XmlContentParser
 import okio.Buffer
-import okio.BufferedSource
 import okio.ByteString.Companion.toByteString
 import okio.Source
 import okio.buffer
@@ -32,7 +32,7 @@ fun KeePassDatabase.Companion.decode(
 ): KeePassDatabase {
     val headerBuffer = Buffer()
 
-    inputStream.source().teeBuffer(headerBuffer).use { source ->
+    inputStream.source().teeBufferStream(headerBuffer).use { source ->
         val header = DatabaseHeader.readFrom(source)
 
         if (header.signature.base != Signature.Base) {
@@ -151,7 +151,7 @@ fun KeePassDatabase.Companion.decodeFromXml(
 
 private fun decryptRawContent(
     header: DatabaseHeader,
-    source: BufferedSource,
+    source: BufferedStream,
     transformedKey: ByteArray
 ): Source {
     val masterSeed = header.masterSeed.toByteArray()

--- a/kotpass/src/main/kotlin/app/keemobile/kotpass/database/header/DatabaseHeader.kt
+++ b/kotpass/src/main/kotlin/app/keemobile/kotpass/database/header/DatabaseHeader.kt
@@ -9,9 +9,9 @@ import app.keemobile.kotpass.extensions.asIntLe
 import app.keemobile.kotpass.extensions.asLongLe
 import app.keemobile.kotpass.extensions.asUuid
 import app.keemobile.kotpass.extensions.nextByteString
+import app.keemobile.kotpass.io.BufferedStream
 import app.keemobile.kotpass.models.FormatVersion
 import okio.BufferedSink
-import okio.BufferedSource
 import okio.ByteString
 import java.nio.ByteBuffer
 import java.security.SecureRandom
@@ -192,7 +192,7 @@ sealed class DatabaseHeader {
     }
 
     companion object {
-        internal fun readFrom(source: BufferedSource): DatabaseHeader {
+        internal fun readFrom(source: BufferedStream): DatabaseHeader {
             var cipherId: CipherId? = null
             var compression: Compression? = null
             var masterSeed: ByteString? = null
@@ -287,7 +287,7 @@ sealed class DatabaseHeader {
         }
 
         private fun readHeaderValue(
-            source: BufferedSource,
+            source: BufferedStream,
             version: FormatVersion
         ): Pair<Int, ByteString> {
             val id = source.readByte()

--- a/kotpass/src/main/kotlin/app/keemobile/kotpass/database/header/Signature.kt
+++ b/kotpass/src/main/kotlin/app/keemobile/kotpass/database/header/Signature.kt
@@ -1,8 +1,8 @@
 package app.keemobile.kotpass.database.header
 
 import app.keemobile.kotpass.extensions.b
+import app.keemobile.kotpass.io.BufferedStream
 import okio.BufferedSink
-import okio.BufferedSource
 import okio.ByteString
 
 class Signature(
@@ -19,7 +19,7 @@ class Signature(
         val Secondary = ByteString.of(0x67, 0xfb.b, 0x4b, 0xb5.b)
         val Default = Signature(Base, Secondary)
 
-        internal fun readFrom(source: BufferedSource) = Signature(
+        internal fun readFrom(source: BufferedStream) = Signature(
             base = source.readByteString(4),
             secondary = source.readByteString(4)
         )

--- a/kotpass/src/main/kotlin/app/keemobile/kotpass/extensions/Node.kt
+++ b/kotpass/src/main/kotlin/app/keemobile/kotpass/extensions/Node.kt
@@ -12,7 +12,7 @@ import java.nio.ByteBuffer
 import java.time.Instant
 import java.util.UUID
 
-internal fun Node.childNodes() = children.filterIsInstance(Node::class.java)
+internal fun Node.childNodes() = children.filterIsInstance<Node>()
 
 internal fun Node.getText() = (children.firstOrNull() as? TextElement)?.text
 

--- a/kotpass/src/main/kotlin/app/keemobile/kotpass/extensions/Source.kt
+++ b/kotpass/src/main/kotlin/app/keemobile/kotpass/extensions/Source.kt
@@ -1,10 +1,15 @@
 package app.keemobile.kotpass.extensions
 
-import app.keemobile.kotpass.io.TeeBufferedSource
+import app.keemobile.kotpass.io.BufferedStream
+import app.keemobile.kotpass.io.RealBufferedStream
+import app.keemobile.kotpass.io.TeeBufferedStream
 import okio.Buffer
-import okio.BufferedSource
 import okio.Source
 
-internal fun Source.teeBuffer(mirrorBuffer: Buffer): BufferedSource {
-    return TeeBufferedSource(this, mirrorBuffer)
+internal fun Source.bufferStream(): BufferedStream {
+    return RealBufferedStream(this)
+}
+
+internal fun Source.teeBufferStream(mirrorBuffer: Buffer): BufferedStream {
+    return TeeBufferedStream(this, mirrorBuffer)
 }

--- a/kotpass/src/main/kotlin/app/keemobile/kotpass/io/BufferedStream.kt
+++ b/kotpass/src/main/kotlin/app/keemobile/kotpass/io/BufferedStream.kt
@@ -1,0 +1,102 @@
+package app.keemobile.kotpass.io
+
+import okio.Buffer
+import okio.BufferedSource
+import okio.ByteString
+import okio.Options
+import okio.Sink
+import okio.Source
+import okio.TypedOptions
+import java.io.InputStream
+import java.nio.channels.ReadableByteChannel
+import java.nio.charset.Charset
+
+interface BufferedStream : Source, ReadableByteChannel {
+    val buffer: Buffer
+
+    fun exhausted(): Boolean
+
+    fun require(byteCount: Long)
+
+    fun request(byteCount: Long): Boolean
+
+    fun readByte(): Byte
+
+    fun readShort(): Short
+
+    fun readShortLe(): Short
+
+    fun readInt(): Int
+
+    fun readIntLe(): Int
+
+    fun readLong(): Long
+
+    fun readLongLe(): Long
+
+    fun readDecimalLong(): Long
+
+    fun readHexadecimalUnsignedLong(): Long
+
+    fun skip(byteCount: Long)
+
+    fun readByteString(): ByteString
+
+    fun readByteString(byteCount: Long): ByteString
+
+    fun select(options: Options): Int
+
+    fun <T : Any> select(options: TypedOptions<T>): T?
+
+    fun readByteArray(): ByteArray
+
+    fun readByteArray(byteCount: Long): ByteArray
+
+    fun read(sink: ByteArray): Int
+
+    fun readFully(sink: ByteArray)
+
+    fun read(sink: ByteArray, offset: Int, byteCount: Int): Int
+
+    fun readFully(sink: Buffer, byteCount: Long)
+
+    fun readAll(sink: Sink): Long
+
+    fun readUtf8(): String
+
+    fun readUtf8(byteCount: Long): String
+
+    fun readUtf8Line(): String?
+
+    fun readUtf8LineStrict(): String
+
+    fun readUtf8LineStrict(limit: Long): String
+
+    fun readUtf8CodePoint(): Int
+
+    fun readString(charset: Charset): String
+
+    fun readString(byteCount: Long, charset: Charset): String
+
+    fun indexOf(b: Byte): Long
+
+    fun indexOf(b: Byte, fromIndex: Long): Long
+
+    fun indexOf(b: Byte, fromIndex: Long, toIndex: Long): Long
+
+    fun indexOf(bytes: ByteString): Long
+
+    fun indexOf(bytes: ByteString, fromIndex: Long): Long
+
+    fun indexOfElement(targetBytes: ByteString): Long
+
+    fun indexOfElement(targetBytes: ByteString, fromIndex: Long): Long
+
+    fun rangeEquals(offset: Long, bytes: ByteString): Boolean
+
+    fun rangeEquals(offset: Long, bytes: ByteString, bytesOffset: Int, byteCount: Int): Boolean
+
+    fun peek(): BufferedSource
+
+    fun inputStream(): InputStream
+}

--- a/kotpass/src/main/kotlin/app/keemobile/kotpass/io/BufferedStream.kt
+++ b/kotpass/src/main/kotlin/app/keemobile/kotpass/io/BufferedStream.kt
@@ -1,102 +1,118 @@
 package app.keemobile.kotpass.io
 
 import okio.Buffer
-import okio.BufferedSource
 import okio.ByteString
-import okio.Options
 import okio.Sink
 import okio.Source
-import okio.TypedOptions
-import java.io.InputStream
 import java.nio.channels.ReadableByteChannel
 import java.nio.charset.Charset
 
-interface BufferedStream : Source, ReadableByteChannel {
+internal interface BufferedStream : Source, ReadableByteChannel {
+    /** Underlying [Buffer]. */
     val buffer: Buffer
 
+    /** Returns *true* if there are no more bytes in this source. */
     fun exhausted(): Boolean
 
-    fun require(byteCount: Long)
-
-    fun request(byteCount: Long): Boolean
-
+    /** Removes a [Byte] from this source and returns it. */
     fun readByte(): Byte
 
+    /** Removes two bytes from this source and returns a big-endian [Short]. */
     fun readShort(): Short
 
+    /** Removes two bytes from this source and returns a little-endian [Short]. */
     fun readShortLe(): Short
 
+    /** Removes four bytes from this source and returns a big-endian [Int]. */
     fun readInt(): Int
 
+    /** Removes four bytes from this source and returns a little-endian [Int]. */
     fun readIntLe(): Int
 
+    /** Removes eight bytes from this source and returns a big-endian [Long]. */
     fun readLong(): Long
 
+    /** Removes eight bytes from this source and returns a little-endian [Long]. */
     fun readLongLe(): Long
 
-    fun readDecimalLong(): Long
-
-    fun readHexadecimalUnsignedLong(): Long
-
-    fun skip(byteCount: Long)
-
+    /** Removes all bytes from this and returns them as a byte string. */
     fun readByteString(): ByteString
 
+    /** Removes [byteCount] bytes from this and returns them as a byte string. */
     fun readByteString(byteCount: Long): ByteString
 
-    fun select(options: Options): Int
-
-    fun <T : Any> select(options: TypedOptions<T>): T?
-
+    /** Removes all bytes from this and returns them as a [ByteArray]. */
     fun readByteArray(): ByteArray
 
+    /** Removes [byteCount] bytes from this and returns them as a [ByteArray]. */
     fun readByteArray(byteCount: Long): ByteArray
 
-    fun read(sink: ByteArray): Int
-
+    /**
+     * Removes exactly `sink.length` bytes from this and copies them into `sink`. Throws an
+     * [EOFException][java.io.EOFException] if the requested number of bytes cannot be read.
+     */
     fun readFully(sink: ByteArray)
 
+    /**
+     * Removes up to `byteCount` bytes from this and copies them into `sink` at `offset`.
+     * Returns the number of bytes read, or -1 if this source is exhausted.
+     */
     fun read(sink: ByteArray, offset: Int, byteCount: Int): Int
 
+    /**
+     * Removes `byteCount` bytes from this and appends them to `sink`.
+     * Throws an [EOFException][java.io.EOFException] if the requested
+     * number of bytes cannot be read.
+     */
     fun readFully(sink: Buffer, byteCount: Long)
 
+    /**
+     * Removes all bytes from this and appends them to the `sink`.
+     * Returns the total number of bytes written to `sink`
+     * which will be 0 if this is exhausted.
+     */
     fun readAll(sink: Sink): Long
 
-    fun readUtf8(): String
+    /** Returns the index of the first `b` in the buffer at or after `fromIndex`. */
+    fun indexOf(b: Byte, fromIndex: Long = 0): Long
 
-    fun readUtf8(byteCount: Long): String
+    /**
+     * Returns the index of the first match for `bytes` in the buffer at or after `fromIndex`.
+     */
+    fun indexOf(bytes: ByteString, fromIndex: Long = 0): Long
 
-    fun readUtf8Line(): String?
-
-    fun readUtf8LineStrict(): String
-
-    fun readUtf8LineStrict(limit: Long): String
-
-    fun readUtf8CodePoint(): Int
-
-    fun readString(charset: Charset): String
-
-    fun readString(byteCount: Long, charset: Charset): String
-
-    fun indexOf(b: Byte): Long
-
-    fun indexOf(b: Byte, fromIndex: Long): Long
-
-    fun indexOf(b: Byte, fromIndex: Long, toIndex: Long): Long
-
-    fun indexOf(bytes: ByteString): Long
-
-    fun indexOf(bytes: ByteString, fromIndex: Long): Long
-
-    fun indexOfElement(targetBytes: ByteString): Long
-
-    fun indexOfElement(targetBytes: ByteString, fromIndex: Long): Long
-
+    /** Returns true if the bytes at `offset` in this source equal `bytes`. */
     fun rangeEquals(offset: Long, bytes: ByteString): Boolean
 
-    fun rangeEquals(offset: Long, bytes: ByteString, bytesOffset: Int, byteCount: Int): Boolean
+    /** Removes all bytes from this, decodes them as `charset`, and returns the string. */
+    fun readString(charset: Charset): String
 
-    fun peek(): BufferedSource
+    /**
+     * Removes `byteCount` bytes from this, decodes them as `charset`,
+     * and returns the [String].
+     */
+    fun readString(byteCount: Long, charset: Charset): String
 
-    fun inputStream(): InputStream
+    /**
+     * Returns *true* when the buffer contains at least [byteCount] bytes,
+     * expanding it as necessary. Returns false if the source is exhausted
+     * before the requested bytes can be read.
+     */
+    fun request(byteCount: Long): Boolean
+
+    /**
+     * Returns when the buffer contains at least [byteCount] bytes.
+     * Throws an [EOFException][java.io.EOFException] if the source
+     * is exhausted before the required bytes can be read.
+     */
+    fun require(byteCount: Long)
+
+    /** Reads and discards [byteCount] bytes from this source. */
+    fun skip(byteCount: Long)
+
+    /**
+     * Returns new [BufferedStream] that can read data from this
+     * [BufferedStream] without consuming it.
+     */
+    fun peek(): BufferedStream
 }

--- a/kotpass/src/main/kotlin/app/keemobile/kotpass/io/RealBufferedStream.kt
+++ b/kotpass/src/main/kotlin/app/keemobile/kotpass/io/RealBufferedStream.kt
@@ -1,64 +1,36 @@
 package app.keemobile.kotpass.io
 
+import app.keemobile.kotpass.extensions.bufferStream
 import okio.Buffer
 import okio.ByteString
-import okio.Options
 import okio.Sink
 import okio.Source
-import okio.TypedOptions
 import okio.buffer
 import java.nio.ByteBuffer
 import java.nio.charset.Charset
 
+/**
+ * [BufferedStream] implementation that essentially wraps sealed
+ * [BufferedSource][okio.BufferedSource] underneath.
+ */
 internal class RealBufferedStream(source: Source) : BufferedStream {
     private val bufferedSource = source.buffer()
 
     override val buffer: Buffer = bufferedSource.buffer
 
+    override fun isOpen() = bufferedSource.isOpen
+
     override fun close() = bufferedSource.close()
 
     override fun exhausted() = bufferedSource.exhausted()
 
-    override fun indexOf(b: Byte) = bufferedSource.indexOf(b)
-
     override fun indexOf(b: Byte, fromIndex: Long) = bufferedSource.indexOf(b, fromIndex)
 
-    override fun indexOf(b: Byte, fromIndex: Long, toIndex: Long) =
-        bufferedSource.indexOf(b, fromIndex, toIndex)
+    override fun indexOf(bytes: ByteString, fromIndex: Long) = bufferedSource
+        .indexOf(bytes, fromIndex)
 
-    override fun indexOf(bytes: ByteString) = bufferedSource.indexOf(bytes)
-
-    override fun indexOf(bytes: ByteString, fromIndex: Long) =
-        bufferedSource.indexOf(bytes, fromIndex)
-
-    override fun indexOfElement(targetBytes: ByteString) =
-        bufferedSource.indexOfElement(targetBytes)
-
-    override fun indexOfElement(targetBytes: ByteString, fromIndex: Long) =
-        bufferedSource.indexOfElement(targetBytes, fromIndex)
-
-    override fun inputStream() = bufferedSource.inputStream()
-
-    override fun isOpen() = bufferedSource.isOpen
-
-    override fun peek() = bufferedSource.peek()
-
-    override fun rangeEquals(offset: Long, bytes: ByteString) =
-        bufferedSource.rangeEquals(offset, bytes)
-
-    override fun rangeEquals(
-        offset: Long,
-        bytes: ByteString,
-        bytesOffset: Int,
-        byteCount: Int
-    ) = bufferedSource.rangeEquals(
-        offset,
-        bytes,
-        bytesOffset,
-        byteCount
-    )
-
-    override fun read(sink: ByteArray) = bufferedSource.read(sink)
+    override fun rangeEquals(offset: Long, bytes: ByteString) = bufferedSource
+        .rangeEquals(offset, bytes)
 
     override fun read(sink: ByteArray, offset: Int, byteCount: Int) = bufferedSource
         .read(sink, offset, byteCount)
@@ -79,14 +51,10 @@ internal class RealBufferedStream(source: Source) : BufferedStream {
 
     override fun readByteString(byteCount: Long) = bufferedSource.readByteString(byteCount)
 
-    override fun readDecimalLong() = bufferedSource.readDecimalLong()
-
     override fun readFully(sink: ByteArray) = bufferedSource.readFully(sink)
 
-    override fun readFully(sink: Buffer, byteCount: Long) =
-        bufferedSource.readFully(sink, byteCount)
-
-    override fun readHexadecimalUnsignedLong() = bufferedSource.readHexadecimalUnsignedLong()
+    override fun readFully(sink: Buffer, byteCount: Long) = bufferedSource
+        .readFully(sink, byteCount)
 
     override fun readInt() = bufferedSource.readInt()
 
@@ -102,30 +70,16 @@ internal class RealBufferedStream(source: Source) : BufferedStream {
 
     override fun readString(charset: Charset) = bufferedSource.readString(charset)
 
-    override fun readString(byteCount: Long, charset: Charset) =
-        bufferedSource.readString(byteCount, charset)
-
-    override fun readUtf8() = bufferedSource.readUtf8()
-
-    override fun readUtf8(byteCount: Long) = bufferedSource.readUtf8(byteCount)
-
-    override fun readUtf8CodePoint() = bufferedSource.readUtf8CodePoint()
-
-    override fun readUtf8Line() = bufferedSource.readUtf8Line()
-
-    override fun readUtf8LineStrict() = bufferedSource.readUtf8LineStrict()
-
-    override fun readUtf8LineStrict(limit: Long) = bufferedSource.readUtf8LineStrict(limit)
+    override fun readString(byteCount: Long, charset: Charset) = bufferedSource
+        .readString(byteCount, charset)
 
     override fun request(byteCount: Long) = bufferedSource.request(byteCount)
 
     override fun require(byteCount: Long) = bufferedSource.require(byteCount)
 
-    override fun select(options: Options) = bufferedSource.select(options)
-
-    override fun <T : Any> select(options: TypedOptions<T>): T? = bufferedSource.select(options)
-
     override fun skip(byteCount: Long) = bufferedSource.skip(byteCount)
+
+    override fun peek() = bufferedSource.peek().bufferStream()
 
     override fun timeout() = bufferedSource.timeout()
 }

--- a/kotpass/src/main/kotlin/app/keemobile/kotpass/io/RealBufferedStream.kt
+++ b/kotpass/src/main/kotlin/app/keemobile/kotpass/io/RealBufferedStream.kt
@@ -1,0 +1,131 @@
+package app.keemobile.kotpass.io
+
+import okio.Buffer
+import okio.ByteString
+import okio.Options
+import okio.Sink
+import okio.Source
+import okio.TypedOptions
+import okio.buffer
+import java.nio.ByteBuffer
+import java.nio.charset.Charset
+
+internal class RealBufferedStream(source: Source) : BufferedStream {
+    private val bufferedSource = source.buffer()
+
+    override val buffer: Buffer = bufferedSource.buffer
+
+    override fun close() = bufferedSource.close()
+
+    override fun exhausted() = bufferedSource.exhausted()
+
+    override fun indexOf(b: Byte) = bufferedSource.indexOf(b)
+
+    override fun indexOf(b: Byte, fromIndex: Long) = bufferedSource.indexOf(b, fromIndex)
+
+    override fun indexOf(b: Byte, fromIndex: Long, toIndex: Long) =
+        bufferedSource.indexOf(b, fromIndex, toIndex)
+
+    override fun indexOf(bytes: ByteString) = bufferedSource.indexOf(bytes)
+
+    override fun indexOf(bytes: ByteString, fromIndex: Long) =
+        bufferedSource.indexOf(bytes, fromIndex)
+
+    override fun indexOfElement(targetBytes: ByteString) =
+        bufferedSource.indexOfElement(targetBytes)
+
+    override fun indexOfElement(targetBytes: ByteString, fromIndex: Long) =
+        bufferedSource.indexOfElement(targetBytes, fromIndex)
+
+    override fun inputStream() = bufferedSource.inputStream()
+
+    override fun isOpen() = bufferedSource.isOpen
+
+    override fun peek() = bufferedSource.peek()
+
+    override fun rangeEquals(offset: Long, bytes: ByteString) =
+        bufferedSource.rangeEquals(offset, bytes)
+
+    override fun rangeEquals(
+        offset: Long,
+        bytes: ByteString,
+        bytesOffset: Int,
+        byteCount: Int
+    ) = bufferedSource.rangeEquals(
+        offset,
+        bytes,
+        bytesOffset,
+        byteCount
+    )
+
+    override fun read(sink: ByteArray) = bufferedSource.read(sink)
+
+    override fun read(sink: ByteArray, offset: Int, byteCount: Int) = bufferedSource
+        .read(sink, offset, byteCount)
+
+    override fun read(sink: Buffer, byteCount: Long) = bufferedSource.read(sink, byteCount)
+
+    override fun read(dst: ByteBuffer?) = bufferedSource.read(dst)
+
+    override fun readAll(sink: Sink): Long = bufferedSource.readAll(sink)
+
+    override fun readByte() = bufferedSource.readByte()
+
+    override fun readByteArray() = bufferedSource.readByteArray()
+
+    override fun readByteArray(byteCount: Long) = bufferedSource.readByteArray(byteCount)
+
+    override fun readByteString() = bufferedSource.readByteString()
+
+    override fun readByteString(byteCount: Long) = bufferedSource.readByteString(byteCount)
+
+    override fun readDecimalLong() = bufferedSource.readDecimalLong()
+
+    override fun readFully(sink: ByteArray) = bufferedSource.readFully(sink)
+
+    override fun readFully(sink: Buffer, byteCount: Long) =
+        bufferedSource.readFully(sink, byteCount)
+
+    override fun readHexadecimalUnsignedLong() = bufferedSource.readHexadecimalUnsignedLong()
+
+    override fun readInt() = bufferedSource.readInt()
+
+    override fun readIntLe() = bufferedSource.readIntLe()
+
+    override fun readLong() = bufferedSource.readLong()
+
+    override fun readLongLe() = bufferedSource.readLongLe()
+
+    override fun readShort() = bufferedSource.readShort()
+
+    override fun readShortLe() = bufferedSource.readShortLe()
+
+    override fun readString(charset: Charset) = bufferedSource.readString(charset)
+
+    override fun readString(byteCount: Long, charset: Charset) =
+        bufferedSource.readString(byteCount, charset)
+
+    override fun readUtf8() = bufferedSource.readUtf8()
+
+    override fun readUtf8(byteCount: Long) = bufferedSource.readUtf8(byteCount)
+
+    override fun readUtf8CodePoint() = bufferedSource.readUtf8CodePoint()
+
+    override fun readUtf8Line() = bufferedSource.readUtf8Line()
+
+    override fun readUtf8LineStrict() = bufferedSource.readUtf8LineStrict()
+
+    override fun readUtf8LineStrict(limit: Long) = bufferedSource.readUtf8LineStrict(limit)
+
+    override fun request(byteCount: Long) = bufferedSource.request(byteCount)
+
+    override fun require(byteCount: Long) = bufferedSource.require(byteCount)
+
+    override fun select(options: Options) = bufferedSource.select(options)
+
+    override fun <T : Any> select(options: TypedOptions<T>): T? = bufferedSource.select(options)
+
+    override fun skip(byteCount: Long) = bufferedSource.skip(byteCount)
+
+    override fun timeout() = bufferedSource.timeout()
+}

--- a/kotpass/src/main/kotlin/app/keemobile/kotpass/io/TeeBufferedStream.kt
+++ b/kotpass/src/main/kotlin/app/keemobile/kotpass/io/TeeBufferedStream.kt
@@ -1,29 +1,22 @@
 package app.keemobile.kotpass.io
 
 import okio.Buffer
-import okio.BufferedSource
 import okio.ByteString
 import okio.Options
 import okio.Sink
 import okio.Source
+import okio.TypedOptions
 import okio.buffer
 import java.nio.ByteBuffer
 import java.nio.charset.Charset
 
-internal class TeeBufferedSource(
+internal class TeeBufferedStream(
     source: Source,
     private val mirrorBuffer: Buffer
-) : BufferedSource {
+) : BufferedStream {
     private val bufferedSource = source.buffer()
 
     override val buffer: Buffer = bufferedSource.buffer
-
-    @Deprecated(
-        "moved to val: use getBuffer() instead",
-        replaceWith = ReplaceWith("buffer"),
-        level = DeprecationLevel.WARNING
-    )
-    override fun buffer(): Buffer = buffer
 
     override fun close() = bufferedSource.close()
 
@@ -198,6 +191,8 @@ internal class TeeBufferedSource(
     override fun require(byteCount: Long) = bufferedSource.require(byteCount)
 
     override fun select(options: Options) = bufferedSource.select(options)
+
+    override fun <T : Any> select(options: TypedOptions<T>): T? = bufferedSource.select(options)
 
     override fun skip(byteCount: Long) = bufferedSource.skip(byteCount)
 

--- a/kotpass/src/main/kotlin/app/keemobile/kotpass/models/FormatVersion.kt
+++ b/kotpass/src/main/kotlin/app/keemobile/kotpass/models/FormatVersion.kt
@@ -1,7 +1,7 @@
 package app.keemobile.kotpass.models
 
+import app.keemobile.kotpass.io.BufferedStream
 import okio.BufferedSink
-import okio.BufferedSource
 
 data class FormatVersion(
     val major: Short,
@@ -17,7 +17,7 @@ data class FormatVersion(
     }
 
     companion object {
-        internal fun readFrom(source: BufferedSource) = FormatVersion(
+        internal fun readFrom(source: BufferedStream) = FormatVersion(
             minor = source.readShortLe(),
             major = source.readShortLe()
         )

--- a/kotpass/src/main/kotlin/app/keemobile/kotpass/xml/DefaultXmlContentParser.kt
+++ b/kotpass/src/main/kotlin/app/keemobile/kotpass/xml/DefaultXmlContentParser.kt
@@ -10,7 +10,6 @@ import org.redundent.kotlin.xml.PrintOptions
 import org.redundent.kotlin.xml.XmlVersion
 import org.redundent.kotlin.xml.parse
 import org.redundent.kotlin.xml.xml
-import java.io.ByteArrayInputStream
 import java.io.InputStream
 
 object DefaultXmlContentParser : XmlContentParser {
@@ -19,7 +18,9 @@ object DefaultXmlContentParser : XmlContentParser {
     override fun unmarshalContent(
         xmlData: ByteArray,
         contextBlock: (Meta) -> XmlContext.Decode
-    ) = unmarshalContent(ByteArrayInputStream(xmlData), contextBlock)
+    ): DatabaseContent = xmlData
+        .inputStream()
+        .use { unmarshalContent(it, contextBlock) }
 
     override fun unmarshalContent(
         source: InputStream,

--- a/kotpass/src/main/kotlin/app/keemobile/kotpass/xml/DefaultXmlContentParser.kt
+++ b/kotpass/src/main/kotlin/app/keemobile/kotpass/xml/DefaultXmlContentParser.kt
@@ -54,12 +54,12 @@ object DefaultXmlContentParser : XmlContentParser {
         pretty: Boolean
     ): String {
         return xml(Tags.Document, XmlEncoding, XmlVersion.V10) {
-            addNode(content.meta.marshal(context))
+            addElement(content.meta.marshal(context))
             Tags.Root {
-                addNode(content.group.marshal(context))
+                addElement(content.group.marshal(context))
                 Tags.DeletedObjects.TagName {
                     content.deletedObjects.forEach {
-                        addNode(it.marshal(context))
+                        addElement(it.marshal(context))
                     }
                 }
             }

--- a/kotpass/src/main/kotlin/app/keemobile/kotpass/xml/Entry.kt
+++ b/kotpass/src/main/kotlin/app/keemobile/kotpass/xml/Entry.kt
@@ -177,23 +177,23 @@ internal fun Entry.marshal(
         Tags.Entry.PreviousParentGroup { addUuid(previousParentGroup) }
     }
     if (times != null) {
-        addNode(times.marshal(context))
+        addElement(times.marshal(context))
     }
     marshalFields(context, fields).forEach {
-        addNode(it)
+        addElement(it)
     }
     binaries.forEach {
-        addNode(it.marshal(context))
+        addElement(it.marshal(context))
     }
     if (customData.isNotEmpty()) {
-        addNode(CustomData.marshal(context, customData))
+        addElement(CustomData.marshal(context, customData))
     }
     if (autoType != null) {
-        addNode(autoType.marshal())
+        addElement(autoType.marshal())
     }
     if (history.isNotEmpty()) {
         Tags.Entry.History {
-            history.forEach { addNode(it.marshal(context)) }
+            history.forEach { addElement(it.marshal(context)) }
         }
     }
 }

--- a/kotpass/src/main/kotlin/app/keemobile/kotpass/xml/Group.kt
+++ b/kotpass/src/main/kotlin/app/keemobile/kotpass/xml/Group.kt
@@ -96,7 +96,7 @@ internal fun Group.marshal(
         Tags.Group.CustomIconId { addUuid(customIconUuid) }
     }
     if (times != null) {
-        addNode(times.marshal(context))
+        addElement(times.marshal(context))
     }
     Tags.Group.IsExpanded { addBoolean(expanded) }
     Tags.Group.DefaultAutoTypeSequence { text(defaultAutoTypeSequence ?: "") }
@@ -112,8 +112,8 @@ internal fun Group.marshal(
         Tags.Group.Tags { text(tags.joinToString(Const.TagsSeparator)) }
     }
     if (customData.isNotEmpty()) {
-        addNode(CustomData.marshal(context, customData))
+        addElement(CustomData.marshal(context, customData))
     }
-    groups.forEach { group -> addNode(group.marshal(context)) }
-    entries.forEach { entry -> addNode(entry.marshal(context)) }
+    groups.forEach { group -> addElement(group.marshal(context)) }
+    entries.forEach { entry -> addElement(entry.marshal(context)) }
 }

--- a/kotpass/src/main/kotlin/app/keemobile/kotpass/xml/Meta.kt
+++ b/kotpass/src/main/kotlin/app/keemobile/kotpass/xml/Meta.kt
@@ -166,16 +166,16 @@ internal fun Meta.marshal(context: XmlContext.Encode): Node {
         Tags.Meta.HistoryMaxSize { text(historyMaxSize.toString()) }
         Tags.Meta.LastSelectedGroup { lastSelectedGroup?.let(this::addUuid) }
         Tags.Meta.LastTopVisibleGroup { lastTopVisibleGroup?.let(this::addUuid) }
-        addNode(marshalMemoryProtection(memoryProtection))
-        addNode(CustomIcons.marshal(context, customIcons))
-        addNode(CustomData.marshal(context, customData))
+        addElement(marshalMemoryProtection(memoryProtection))
+        addElement(CustomIcons.marshal(context, customIcons))
+        addElement(CustomData.marshal(context, customData))
 
         // In version 4.x files are stored in binary inner header
         if (context.version.major < 4) {
             Tags.Meta.Binaries.TagName {
                 var binaryCount = 0
                 for ((_, binary) in binaries) {
-                    addNode(binary.marshal(binaryCount))
+                    addElement(binary.marshal(binaryCount))
                     binaryCount++
                 }
             }

--- a/kotpass/src/test/kotlin/app/keemobile/kotpass/database/ContentBlocksSpec.kt
+++ b/kotpass/src/test/kotlin/app/keemobile/kotpass/database/ContentBlocksSpec.kt
@@ -1,5 +1,6 @@
 package app.keemobile.kotpass.database
 
+import app.keemobile.kotpass.extensions.bufferStream
 import app.keemobile.kotpass.resources.ContentBlocksRes
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldNotBe
@@ -34,7 +35,7 @@ class ContentBlocksSpec : DescribeSpec({
                 transformedKey = key
             )
             val output = ContentBlocks
-                .readContentBlocksVer4x(buffer, seed, key)
+                .readContentBlocksVer4x(buffer.bufferStream(), seed, key)
                 .toString(Charsets.UTF_8)
 
             output.indexOf(ContentBlocksRes.TestSentence) shouldNotBe -1

--- a/kotpass/src/test/kotlin/app/keemobile/kotpass/database/header/DatabaseHeaderSpec.kt
+++ b/kotpass/src/test/kotlin/app/keemobile/kotpass/database/header/DatabaseHeaderSpec.kt
@@ -1,10 +1,10 @@
 package app.keemobile.kotpass.database.header
 
+import app.keemobile.kotpass.extensions.bufferStream
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import okio.Buffer
-import okio.buffer
 import okio.source
 
 class DatabaseHeaderSpec : DescribeSpec({
@@ -36,7 +36,7 @@ class DatabaseHeaderSpec : DescribeSpec({
                     .toByteArray()
                     .inputStream()
                     .source()
-                    .buffer()
+                    .bufferStream()
             }.let(DatabaseHeader.Companion::readFrom)
 
             ver4Argon2.signature.base shouldBe Signature.Base
@@ -50,4 +50,4 @@ class DatabaseHeaderSpec : DescribeSpec({
 
 private fun decodeHeader(fileName: String) = ClassLoader
     .getSystemResourceAsStream(fileName)!!
-    .use { DatabaseHeader.readFrom(it.source().buffer()) }
+    .use { DatabaseHeader.readFrom(it.source().bufferStream()) }

--- a/kotpass/src/test/kotlin/app/keemobile/kotpass/io/TeeBufferedStreamSpec.kt
+++ b/kotpass/src/test/kotlin/app/keemobile/kotpass/io/TeeBufferedStreamSpec.kt
@@ -16,7 +16,7 @@ private val DummyData = "Lorem ipsum".toByteArray()
 class TeeBufferedStreamSpec : DescribeSpec({
 
     describe("TeeBufferedStream") {
-        it("Writes data to side buffer") {
+        it("Writes data to the side buffer") {
             val buffer = Buffer()
             val data = ByteString.of(*DummyData)
             val tee = ByteArrayInputStream(DummyData)
@@ -31,6 +31,17 @@ class TeeBufferedStreamSpec : DescribeSpec({
 
             tee.readFully(ByteArray((data.size - buffer.size).toInt()))
             buffer.snapshot() shouldBe data
+        }
+
+        it("Does not write data to the side buffer while peeking") {
+            val buffer = Buffer()
+            val tee = ByteArrayInputStream(DummyData)
+                .source()
+                .teeBufferStream(buffer)
+                .peek()
+
+            tee.read(Buffer(), 5)
+            buffer.snapshot().size shouldBe 0
         }
     }
 })

--- a/kotpass/src/test/kotlin/app/keemobile/kotpass/io/TeeBufferedStreamSpec.kt
+++ b/kotpass/src/test/kotlin/app/keemobile/kotpass/io/TeeBufferedStreamSpec.kt
@@ -2,7 +2,7 @@
 
 package app.keemobile.kotpass.io
 
-import app.keemobile.kotpass.extensions.teeBuffer
+import app.keemobile.kotpass.extensions.teeBufferStream
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import okio.Buffer
@@ -13,15 +13,15 @@ import java.nio.ByteBuffer
 
 private val DummyData = "Lorem ipsum".toByteArray()
 
-class TeeSourceSpec : DescribeSpec({
+class TeeBufferedStreamSpec : DescribeSpec({
 
-    describe("TeeBufferedSource") {
+    describe("TeeBufferedStream") {
         it("Writes data to side buffer") {
             val buffer = Buffer()
             val data = ByteString.of(*DummyData)
             val tee = ByteArrayInputStream(DummyData)
                 .source()
-                .teeBuffer(buffer)
+                .teeBufferStream(buffer)
 
             tee.read(Buffer(), 5)
             buffer.snapshot() shouldBe data.substring(0, 5)


### PR DESCRIPTION
# Description

- Fixed some streams not being closed during decoding.
- Use `gzip` operator on `Source` instead of `GZIPInputStream`.
- Migrate to latest `okio` and `xml-builder` versions.